### PR TITLE
Add basic structure (command, query, api)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <version>4.0.3</version>
         <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>com.tngtech.archunit</groupId>
+        <artifactId>archunit-junit4</artifactId>
+        <version>0.9.2</version>
+        <scope>test</scope>
+    </dependency>
 </dependencies>
 
 <build>

--- a/src/main/java/com/example/api/package-info.java
+++ b/src/main/java/com/example/api/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * API - Command, Queries and Events
+ */
+package com.example.api;

--- a/src/main/java/com/example/command/package-info.java
+++ b/src/main/java/com/example/command/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Command model - Aggregates, Sagas, Command Handlers, Event Sourcing Handlers, ...
+ */
+package com.example.command;

--- a/src/main/java/com/example/query/package-info.java
+++ b/src/main/java/com/example/query/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Query/Read model - Query Handlers, Event handlers, Projections
+ */
+package com.example.query;

--- a/src/main/java/com/example/web/AxonJavaSpringSeedRestController.java
+++ b/src/main/java/com/example/web/AxonJavaSpringSeedRestController.java
@@ -1,4 +1,4 @@
-package com.example;
+package com.example.web;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/example/web/package-info.java
+++ b/src/main/java/com/example/web/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Web - Web Controllers/Adapters
+ */
+package com.example.web;

--- a/src/test/java/com/example/AxonJavaSpringMavenSeedArchitectureTests.java
+++ b/src/test/java/com/example/AxonJavaSpringMavenSeedArchitectureTests.java
@@ -1,0 +1,24 @@
+package com.example;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import org.junit.runner.RunWith;
+
+@RunWith(ArchUnitRunner.class)
+@AnalyzeClasses(packagesOf = AxonJavaSpringMavenSeedArchitectureTests.class)
+public class AxonJavaSpringMavenSeedArchitectureTests {
+
+    /**
+     * Testing if the classes in "..command.. , ..query.. " packages are `package private`.
+     * <p>
+     * This will work with Java only. Kotlin does not have package modifier.
+     */
+    @ArchTest
+    public static final ArchRule encapsulationJavaRule = ArchRuleDefinition.classes()
+            .that().resideInAnyPackage("..command..", "..query..")
+            .should().bePackagePrivate();
+
+}


### PR DESCRIPTION
Test the rule to have `package private` classes in
`command` and `query` packages only